### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/deveshwaingankar/CardPlay/security/code-scanning/1](https://github.com/deveshwaingankar/CardPlay/security/code-scanning/1)

To fix the issue, we should add a `permissions` block for the `build` job to explicitly specify the minimal permissions required. Since the `build` job only runs tests and does not modify the repository or interact with GitHub resources, it only needs `contents: read`. This change ensures that the `build` job adheres to the principle of least privilege and avoids inheriting unnecessary permissions from the repository settings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
